### PR TITLE
Display images without antialiasing

### DIFF
--- a/docs/rw.css
+++ b/docs/rw.css
@@ -261,4 +261,10 @@ input[type='checkbox'].rw-ui, input[type='radio'].rw-ui {
     input[type='checkbox'].rw-ui-ckb:active + label {
         color: white;
     }
+
+/* STOP ANTIALIASING */
+img {
+    image-rendering: pixelated;
+}
+
 /* RW UI END */


### PR DESCRIPTION
Hi! Thanks for making this amazing tool.

A small detail that bugs me is that zooming into the interactive map results in blurry images as a result of browser antialiasing.

Before:
![image](https://github.com/user-attachments/assets/67de80a5-59c2-41f0-8fbe-3b23850cdd30)

After:
![image](https://github.com/user-attachments/assets/32bbbc9e-669f-420c-9ff1-55419eda27fb)

Thanks!